### PR TITLE
Add fog shader to camera

### DIFF
--- a/Assets/Materials/Fog.mat
+++ b/Assets/Materials/Fog.mat
@@ -1,0 +1,82 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Fog
+  m_Shader: {fileID: 4800000, guid: 2dc4658760d7b874d91152a9b2d1fcc3, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _FogDensity: 58.4
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _FogColor: {r: 0.0972, g: 0.116432056, b: 0.18, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/Fog.mat.meta
+++ b/Assets/Materials/Fog.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49e3b50d23d275948b17aeddf0b85a45
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -188,6 +188,7 @@ GameObject:
   - component: {fileID: 8897005193119557359}
   - component: {fileID: 8897005193119557352}
   - component: {fileID: 8897005193119557353}
+  - component: {fileID: 406442812}
   m_Layer: 2
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -263,6 +264,19 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8897005193119557354}
   m_Enabled: 1
+--- !u!114 &406442812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8897005193119557354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30cc7f902ac94e642bdc7b4917b8cf9b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  material: {fileID: 2100000, guid: 49e3b50d23d275948b17aeddf0b85a45, type: 2}
 --- !u!1 &9004047637359721981
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ApplyFogToCamera.cs
+++ b/Assets/Scripts/ApplyFogToCamera.cs
@@ -1,0 +1,29 @@
+// From https://en.wikibooks.org/wiki/Cg_Programming/Unity/Minimal_Image_Effect
+
+using System;
+using UnityEngine;
+
+[RequireComponent(typeof(Camera))]
+[ExecuteInEditMode]
+
+public class ApplyFogToCamera : MonoBehaviour
+{
+
+    public Material material;
+
+    void Start()
+    {
+        if (null == material || null == material.shader ||
+           !material.shader.isSupported)
+        {
+            enabled = false;
+            return;
+        }
+    }
+
+    void OnRenderImage(RenderTexture source, RenderTexture destination)
+    {
+        Debug.Log("Rendering");
+        Graphics.Blit(source, destination, material);
+    }
+}

--- a/Assets/Scripts/ApplyFogToCamera.cs.meta
+++ b/Assets/Scripts/ApplyFogToCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30cc7f902ac94e642bdc7b4917b8cf9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45b1d113c47d0d442a3b823ba12eb88c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Fog.shader
+++ b/Assets/Shaders/Fog.shader
@@ -1,0 +1,65 @@
+﻿// From https://github.com/KaimaChen/Unity-Shader-Demo/blob/master/UnityShaderProject/Assets/Depth/Shaders/Fog.shader
+Shader "Kaima/Depth/Fog"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+		_FogColor("Fog Color", Color) = (1,1,1,1)
+		_FogDensity("Fog Density", Float) = 1
+	}
+	SubShader
+	{
+		// No culling or depth
+		Cull Off ZWrite Off ZTest Always
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float4 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			sampler2D _MainTex;
+			float4 _MainTex_TexelSize;
+			sampler2D _CameraDepthTexture;
+			fixed4 _FogColor;
+			float _FogDensity;
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = float4(v.uv, v.uv);
+				#if UNITY_UV_STARTS_AT_TOP
+					if(_MainTex_TexelSize.y < 0)
+						o.uv.w = 1 - o.uv.w;
+				#endif
+				return o;
+			}
+			
+			fixed4 frag (v2f i) : SV_Target
+			{
+				fixed4 col = tex2D(_MainTex, i.uv.xy);
+				float depth = UNITY_SAMPLE_DEPTH(tex2D(_CameraDepthTexture, i.uv.zw));
+				float linearDepth = Linear01Depth(depth);
+				float fogDensity = saturate(linearDepth * _FogDensity);
+				fixed4 finalColor = lerp(col, _FogColor, fogDensity);
+				return finalColor;
+			}
+			ENDCG
+		}
+	}
+}

--- a/Assets/Shaders/Fog.shader.meta
+++ b/Assets/Shaders/Fog.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2dc4658760d7b874d91152a9b2d1fcc3
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a quick distance-based fog shader I found online to the camera. We can tweak this more in the future.

Example render:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/4943979/214993866-667fff6f-92d1-4a5e-94c0-c01cd3313771.png">

Note that the fog shader is drawing on top of the torch, but we can tweak that later