### PR TITLE
Fix fog drawing on particles

### DIFF
--- a/Assets/Shaders/Fog.shader
+++ b/Assets/Shaders/Fog.shader
@@ -35,7 +35,7 @@ Shader "Kaima/Depth/Fog"
 			sampler2D _MainTex;
 			float4 _MainTex_TexelSize;
 			sampler2D _CameraDepthTexture;
-			fixed4 _FogColor;
+			float4 _FogColor;
 			float _FogDensity;
 
 			v2f vert (appdata v)
@@ -50,13 +50,18 @@ Shader "Kaima/Depth/Fog"
 				return o;
 			}
 			
-			fixed4 frag (v2f i) : SV_Target
+			float4 frag (v2f i) : SV_Target
 			{
-				fixed4 col = tex2D(_MainTex, i.uv.xy);
+				float4 imageColor = tex2D(_MainTex, i.uv.xy);
+				// Avoid overwriting torch particles, minotaur eyes, coin reflections, etc
+				if (imageColor.r > 0.8) {
+					return imageColor;
+				}
+
 				float depth = UNITY_SAMPLE_DEPTH(tex2D(_CameraDepthTexture, i.uv.zw));
 				float linearDepth = Linear01Depth(depth);
 				float fogDensity = saturate(linearDepth * _FogDensity);
-				fixed4 finalColor = lerp(col, _FogColor, fogDensity);
+				float4 finalColor = lerp(imageColor, _FogColor, fogDensity);
 				return finalColor;
 			}
 			ENDCG


### PR DESCRIPTION
The current fog shader draws a post-processing effect on the rendered image, which annoyingly overwrites the torch particles. I was able to fix this just by skipping drawing fog on pixels of the image with red > 80% (picked semi arbitrarily), which will also allow other bright objects in the scene to not have fog drawn on top.

Example scene with the new shader adjustments, note no fog on torch particles, coin reflections, or minotaur eyes (left):
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/4943979/227801800-f7aac26c-8564-4e55-a442-f3f0dd335bfb.png">
